### PR TITLE
Bug fix: avoid panic when group's ImportState searches for a group pa…

### DIFF
--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -256,10 +256,17 @@ func (t *groupResource) ImportState(ctx context.Context,
 	found, err := t.client.Group.GetGroup(ctx, &ttypes.GetGroupInput{
 		Path: &req.ID,
 	})
-	if (err != nil) || (found == nil) {
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Import group not found: "+req.ID,
 			err.Error(),
+		)
+		return
+	}
+	if found == nil {
+		resp.Diagnostics.AddError(
+			"Import group not found: "+req.ID,
+			"",
 		)
 		return
 	}


### PR DESCRIPTION
Bug fix: avoid panic when group's ImportState searches for a group path that does not exist.  Same fix as an earlier review item in the workspace module.  Fix has been tested manually for both found and not-found paths.
