### PR TITLE
Support bool and number outputs in tharsis_workspace_outputs

### DIFF
--- a/internal/provider/data_source_workspace_outputs.go
+++ b/internal/provider/data_source_workspace_outputs.go
@@ -189,53 +189,61 @@ func (t workspaceOutputsDataSource) Read(ctx context.Context,
 		}
 
 		for _, output := range outputsResp.StateVersionOutputs {
-			outputType, err := ctyjson.UnmarshalType(output.Type)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					fmt.Sprintf("Failed to parse type from output \"%s\"", output.Name),
-					err.Error(),
-				)
-				return
-			}
-
 			if !t.isJSONEncoded {
+				outputType, err := ctyjson.UnmarshalType(output.Type)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						fmt.Sprintf("Failed to parse type from output %q", output.Name),
+						err.Error(),
+					)
+					return
+				}
+
 				switch outputType {
-				// Currently Strings are only supported
-				case cty.String:
+				case cty.String, cty.Bool, cty.Number:
 				default:
-					// Unsupported types for non-json encoded provider need to be skipped
+					resp.Diagnostics.AddWarning(
+						fmt.Sprintf("Skipping output %q", output.Name),
+						fmt.Sprintf("Output %q has a complex type that is not supported by tharsis_workspace_outputs. Use tharsis_workspace_outputs_json instead.", output.Name),
+					)
 					continue
 				}
-			}
 
-			outputValue, err := ctyjson.Unmarshal(output.Value, outputType)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					fmt.Sprintf("Failed to parse value from output \"%s\"", output.Name),
-					err.Error(),
-				)
-				return
-			}
-
-			b, err := ctyjson.Marshal(outputValue, outputType)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					fmt.Sprintf("Fail to parse value from output \"%s\"", output.Name),
-					err.Error(),
-				)
-			}
-
-			if !t.isJSONEncoded {
-				var s string
-				if err := json.Unmarshal(b, &s); err != nil {
+				s, err := convertOutputToString(outputType, output.Value)
+				if err != nil {
 					resp.Diagnostics.AddError(
-						fmt.Sprintf("Failed to parse value from output \"%s\"", output.Name),
+						fmt.Sprintf("Failed to parse output %q", output.Name),
 						err.Error(),
 					)
 					return
 				}
 				data.Outputs[output.Name] = s
 			} else {
+				outputType, err := ctyjson.UnmarshalType(output.Type)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						fmt.Sprintf("Failed to parse type from output %q", output.Name),
+						err.Error(),
+					)
+					return
+				}
+
+				outputValue, err := ctyjson.Unmarshal(output.Value, outputType)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						fmt.Sprintf("Failed to parse value from output %q", output.Name),
+						err.Error(),
+					)
+					return
+				}
+
+				b, err := ctyjson.Marshal(outputValue, outputType)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						fmt.Sprintf("Failed to parse value from output %q", output.Name),
+						err.Error(),
+					)
+				}
 				data.Outputs[output.Name] = string(b)
 			}
 		}
@@ -251,6 +259,38 @@ func (t workspaceOutputsDataSource) Read(ctx context.Context,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// convertOutputToString converts a state version output with a primitive type
+// (string, bool, number) to its string representation.
+func convertOutputToString(outputType cty.Type, valueBytes []byte) (string, error) {
+	outputValue, err := ctyjson.Unmarshal(valueBytes, outputType)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse value: %w", err)
+	}
+
+	b, err := ctyjson.Marshal(outputValue, outputType)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal value: %w", err)
+	}
+
+	switch outputType {
+	case cty.String:
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return "", fmt.Errorf("failed to parse string value: %w", err)
+		}
+		return s, nil
+
+	case cty.Bool, cty.Number:
+		raw := string(b)
+		if raw == "null" {
+			return "", nil
+		}
+		return raw, nil
+	}
+
+	return "", fmt.Errorf("unsupported type")
 }
 
 func resolvePath(path string) (string, error) {

--- a/internal/provider/data_source_workspace_outputs_test.go
+++ b/internal/provider/data_source_workspace_outputs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestAccWorkspaceOutputsDataSource(t *testing.T) {
@@ -63,6 +64,91 @@ data "tharsis_workspace_outputs" "by_uuid" {
   id = tharsis_workspace.test.id
 }
 `, testSharedProviderConfiguration(), groupName, workspaceName)
+}
+
+func Test_outputConversion(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputType  cty.Type
+		outputValue []byte
+		wantValue   string
+		wantErr     bool
+	}{
+		{
+			name:        "string output is included",
+			outputType:  cty.String,
+			outputValue: []byte(`"hello"`),
+			wantValue:   "hello",
+		},
+		{
+			name:        "bool true output is included",
+			outputType:  cty.Bool,
+			outputValue: []byte(`true`),
+			wantValue:   "true",
+		},
+		{
+			name:        "bool false output is included",
+			outputType:  cty.Bool,
+			outputValue: []byte(`false`),
+			wantValue:   "false",
+		},
+		{
+			name:        "number output is included",
+			outputType:  cty.Number,
+			outputValue: []byte(`42`),
+			wantValue:   "42",
+		},
+		{
+			name:        "null bool output is empty string",
+			outputType:  cty.Bool,
+			outputValue: []byte(`null`),
+			wantValue:   "",
+		},
+		{
+			name:        "null number output is empty string",
+			outputType:  cty.Number,
+			outputValue: []byte(`null`),
+			wantValue:   "",
+		},
+		{
+			name:        "null string output is empty string",
+			outputType:  cty.String,
+			outputValue: []byte(`null`),
+			wantValue:   "",
+		},
+		{
+			name:        "large number output",
+			outputType:  cty.Number,
+			outputValue: []byte(`1e+20`),
+			wantValue:   "100000000000000000000",
+		},
+		{
+			name:        "unsupported type returns error",
+			outputType:  cty.DynamicPseudoType,
+			outputValue: []byte(`"anything"`),
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := convertOutputToString(tt.outputType, tt.outputValue)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if value != tt.wantValue {
+				t.Errorf("got %q, want %q", value, tt.wantValue)
+			}
+		})
+	}
 }
 
 func Test_resolvePath(t *testing.T) {


### PR DESCRIPTION
The tharsis_workspace_outputs data source previously only included string-typed outputs and silently dropped all others. This caused confusing "Invalid index" errors when accessing boolean or number outputs (e.g., review_apps_enabled = true), with no indication that the key was being filtered out.

### Changes

- Bool and number outputs are now included in the outputs map, converted to their string representation (e.g., "true", "42")
- Complex types (lists, maps, objects) are still skipped but now emit a warning directing users to tharsis_workspace_outputs_json
- Added unit tests covering primitive type inclusion and complex type skipping

### Context

This caused production failures in workspaces consuming boolean outputs from sibling workspaces. The only workaround was switching to tharsis_workspace_outputs_json with jsondecode() on every value.