### PR TITLE
Support run queuing status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,17 +102,31 @@ jobs:
           TF_ACC: "1"
           THARSIS_ENDPOINT: http://localhost:8000
         run: |
-          THARSIS_STATIC_TOKEN=$(curl -s -X POST 'http://localhost:8000/oauth/login' \
+          # Log in using the OAuth2 resource owner password credentials grant.
+          THARSIS_STATIC_TOKEN=$(curl -s -X POST 'http://localhost:8000/oauth/token' \
           -H 'Content-Type: application/x-www-form-urlencoded' \
+          --data-urlencode 'grant_type=password' \
+          --data-urlencode 'client_id=tharsis' \
           --data-urlencode 'username=martian' \
           --data-urlencode 'password=martian' \
-          --data-urlencode 'client_id=tharsis' \
-          --data-urlencode 'redirect_uri=http://localhost:3000/callback' \
-          --data-urlencode 'response_type=code' \
-          --data-urlencode 'state=test' \
-          --data-urlencode 'scope=openid tharsis' \
-          --data-urlencode 'code_challenge=test_challenge' \
-          --data-urlencode 'code_challenge_method=S256' \
-          -D - | grep 'tharsis_access_token=' | sed 's/.*tharsis_access_token=\([^;]*\).*/\1/')
+          --data-urlencode 'scope=openid tharsis' | jq -r '.access_token')
+
+          if [ -z "$THARSIS_STATIC_TOKEN" ] || [ "$THARSIS_STATIC_TOKEN" = "null" ]; then
+            echo "Failed to obtain access token"
+            exit 1
+          fi
           export THARSIS_STATIC_TOKEN
+
+          # Activate admin mode for the logged-in user.
+          ADMIN_MODE_RESPONSE=$(curl -s -X POST 'http://localhost:8000/graphql' \
+          -H "Authorization: Bearer ${THARSIS_STATIC_TOKEN}" \
+          -H 'Content-Type: application/json' \
+          --data '{"query":"mutation { activateAdminMode(input: {}) { problems { message type } } }"}')
+
+          echo "Activate admin mode response: ${ADMIN_MODE_RESPONSE}"
+          if [ "$(echo "$ADMIN_MODE_RESPONSE" | jq '((.errors // []) | length) + ((.data.activateAdminMode.problems // []) | length)')" != "0" ]; then
+            echo "Failed to activate admin mode"
+            exit 1
+          fi
+
           go test -v -cover ./internal/provider/

--- a/internal/provider/resource_apply_module.go
+++ b/internal/provider/resource_apply_module.go
@@ -457,6 +457,19 @@ func (t *applyModuleResource) createRun(ctx context.Context, input *createRunInp
 		return nil, diags
 	}
 
+	// Wait until the plan job has been created before requesting it, to avoid a race
+	// where the job does not yet exist. The plan status is the authoritative signal.
+	if err = t.waitForRunJob(ctx, createdRun.WorkspaceId, createdRun.Metadata.Id, func(ctx context.Context) (string, error) {
+		plan, pErr := t.client.RunsClient.GetPlanByID(ctx, &pb.GetPlanByIDRequest{Id: createdRun.PlanId})
+		if pErr != nil {
+			return "", pErr
+		}
+		return plan.Status, nil
+	}, planJobReady); err != nil {
+		diags.AddError("Failed waiting for plan job", err.Error())
+		return nil, diags
+	}
+
 	// Wait for plan job.
 	planJob, err := t.client.JobsClient.GetLatestJobForPlan(ctx, &pb.GetLatestJobForPlanRequest{
 		PlanId: createdRun.PlanId,
@@ -478,11 +491,12 @@ func (t *applyModuleResource) createRun(ctx context.Context, input *createRunInp
 		return nil, diags
 	}
 
+	// Plan status arrives as the lowercased proto status value on the wire.
 	switch plan.Status {
-	case pb.PlanStatus_CANCELED.String():
+	case "canceled":
 		diags.AddError("Plan was canceled", plan.Status)
 		return nil, diags
-	case pb.PlanStatus_ERRORED.String():
+	case "errored":
 		msg := "Plan failed with unknown error"
 		if plan.ErrorMessage != nil {
 			msg = *plan.ErrorMessage
@@ -521,6 +535,19 @@ func (t *applyModuleResource) createRun(ctx context.Context, input *createRunInp
 		return nil, diags
 	}
 
+	// Wait until the apply job has been created before requesting it, to avoid a race
+	// where the job does not yet exist. The apply status is the authoritative signal.
+	if err = t.waitForRunJob(ctx, appliedRun.WorkspaceId, runID, func(ctx context.Context) (string, error) {
+		apply, aErr := t.client.RunsClient.GetApplyByID(ctx, &pb.GetApplyByIDRequest{Id: appliedRun.ApplyId})
+		if aErr != nil {
+			return "", aErr
+		}
+		return apply.Status, nil
+	}, applyJobReady); err != nil {
+		diags.AddError("Failed waiting for apply job", err.Error())
+		return nil, diags
+	}
+
 	// Wait for apply job.
 	applyJob, err := t.client.JobsClient.GetLatestJobForApply(ctx, &pb.GetLatestJobForApplyRequest{
 		ApplyId: appliedRun.ApplyId,
@@ -542,11 +569,12 @@ func (t *applyModuleResource) createRun(ctx context.Context, input *createRunInp
 		return nil, diags
 	}
 
+	// Apply status arrives as the lowercased proto status value on the wire.
 	switch apply.Status {
-	case pb.ApplyStatus_CANCELED.String():
+	case "canceled":
 		diags.AddError("Apply was canceled", apply.Status)
 		return nil, diags
-	case pb.ApplyStatus_ERRORED.String():
+	case "errored":
 		msg := "Apply failed with unknown error"
 		if apply.ErrorMessage != nil {
 			msg = *apply.ErrorMessage
@@ -579,6 +607,98 @@ func (t *applyModuleResource) createRun(ctx context.Context, input *createRunInp
 		resolvedVariables: resolvedApplyVarsResp.Variables,
 		moduleVersion:     *createdRun.ModuleVersion,
 	}, diags
+}
+
+// waitForRunJob blocks until ready reports the plan/apply job has been created. It
+// checks the current status first, then subscribes to run events as a wake-up signal,
+// re-checking the authoritative plan/apply status (getStatus) on each event. It returns
+// an error if the plan/apply reaches a final state before a job becomes available, or
+// if the run event stream cannot be established or closes first.
+func (t *applyModuleResource) waitForRunJob(
+	ctx context.Context,
+	workspaceID, runID string,
+	getStatus func(context.Context) (string, error),
+	ready func(status string) (bool, error),
+) error {
+	// Check current state first; the subscription does not replay current state, so a
+	// transition that already happened could otherwise be missed.
+	status, err := getStatus(ctx)
+	if err != nil {
+		return err
+	}
+	if done, rErr := ready(status); rErr != nil || done {
+		return rErr
+	}
+
+	// Subscribe to run events for wake-ups. The server keeps the subscription open
+	// until the RPC is canceled, so use a child context that is canceled on return to
+	// tear the stream down once the job is available.
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := t.client.RunsClient.SubscribeToRunEvents(subCtx, &pb.SubscribeToRunEventsRequest{
+		WorkspaceId: &workspaceID,
+		RunId:       &runID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to run events: %w", err)
+	}
+
+	for {
+		// Block until the next run event, then re-check the authoritative status.
+		_, recvErr := stream.Recv()
+
+		status, err := getStatus(ctx)
+		if err != nil {
+			return err
+		}
+		done, err := ready(status)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		// The stream closed before the job became available; the status above is the
+		// most current we can get, so report the stream failure.
+		if recvErr != nil {
+			return fmt.Errorf("run event stream closed before a job was available: %w", recvErr)
+		}
+	}
+}
+
+// planJobReady reports whether the plan's job has been created, based on the plan
+// status (the lowercased proto status values sent on the wire). A job exists once the
+// plan reaches queued and through its terminal states. A plan that reaches a final
+// state without a job (canceled) is an error.
+func planJobReady(status string) (bool, error) {
+	switch status {
+	case "queued", "running", "finished", "errored":
+		// A job exists.
+		return true, nil
+	case "canceled":
+		return false, fmt.Errorf("plan reached final state before a job was available; status: %s", status)
+	default:
+		// pending: job not created yet.
+		return false, nil
+	}
+}
+
+// applyJobReady reports whether the apply's job has been created, based on the apply
+// status. A job exists once the apply reaches queued and through its terminal states.
+// An apply that reaches a final state without a job (canceled) is an error.
+func applyJobReady(status string) (bool, error) {
+	switch status {
+	case "queued", "running", "finished", "errored":
+		// A job exists.
+		return true, nil
+	case "canceled":
+		return false, fmt.Errorf("apply reached final state before a job was available; status: %s", status)
+	default:
+		// created, pending: job not created yet.
+		return false, nil
+	}
 }
 
 func (t *applyModuleResource) waitForJobCompletion(ctx context.Context, jobID string) error {


### PR DESCRIPTION
Support run queuing status by waiting for job to be available before querying for job logs.